### PR TITLE
Add 3D particle background

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Pavlestial Portfolio
+
+This is a static portfolio site with a Three.js particle background. The project includes a `netlify.toml` file so it can be deployed directly to Netlify.
+
+## Deploying to Netlify
+
+1. Create a free account at [Netlify](https://www.netlify.com/).
+2. From the Netlify dashboard choose **"Add new site"** > **"Import an existing project"** and connect your Git repository.
+3. When prompted for build settings, use the following:
+   - **Build command:** *(leave empty)*
+   - **Publish directory:** `./`
+4. Click **Deploy Site**. Netlify will build and host the site automatically.
+
+To preview a deployment locally you can use the Netlify CLI:
+
+```bash
+npm install -g netlify-cli  # if not installed
+netlify dev
+```
+
+This will serve the site at `http://localhost:8888` using the settings from `netlify.toml`.

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <canvas id="bg"></canvas>
     <!-- Header -->
     <header id="header">
         <div class="container">
@@ -286,6 +287,7 @@
 
     <!-- JavaScript -->
     <script src="script.js"></script>
+    <script type="module" src="particles.js"></script>
 </body>
 </html>
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  publish = "./"
+  command = ""
+
+[context.production.environment]
+  NODE_VERSION = "18"

--- a/particles.js
+++ b/particles.js
@@ -1,0 +1,98 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.158.0/build/three.module.js';
+import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.158.0/examples/jsm/controls/OrbitControls.js';
+import { EffectComposer } from 'https://cdn.jsdelivr.net/npm/three@0.158.0/examples/jsm/postprocessing/EffectComposer.js';
+import { RenderPass } from 'https://cdn.jsdelivr.net/npm/three@0.158.0/examples/jsm/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'https://cdn.jsdelivr.net/npm/three@0.158.0/examples/jsm/postprocessing/UnrealBloomPass.js';
+
+const canvas = document.getElementById('bg');
+const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+renderer.setPixelRatio(window.devicePixelRatio);
+renderer.setSize(window.innerWidth, window.innerHeight);
+
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 100);
+camera.position.z = 5;
+
+const controls = new OrbitControls(camera, renderer.domElement);
+
+const COUNT = 10000;
+const geometry = new THREE.BufferGeometry();
+const offsets = new Float32Array(COUNT * 3);
+for (let i = 0; i < COUNT * 3; i++) {
+    offsets[i] = (Math.random() - 0.5) * 4.0;
+}
+geometry.setAttribute('offset', new THREE.BufferAttribute(offsets, 3));
+
+const vertexShader = `
+    uniform float time;
+    uniform vec3 paramsA;
+    uniform vec3 paramsB;
+    uniform float morph;
+    attribute vec3 offset;
+
+    vec3 pattern(vec3 p, vec3 k) {
+        p += vec3(
+            sin(p.y * k.x + time),
+            sin(p.z * k.y + time),
+            sin(p.x * k.z + time)
+        );
+        return p;
+    }
+
+    void main() {
+        vec3 pa = pattern(offset, paramsA);
+        vec3 pb = pattern(offset, paramsB);
+        vec3 pos = mix(pa, pb, morph);
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
+        gl_PointSize = 2.0;
+    }
+`;
+
+const fragmentShader = `
+    void main() {
+        float d = length(gl_PointCoord - 0.5);
+        if(d > 0.5) discard;
+        gl_FragColor = vec4(1.0);
+    }
+`;
+
+const material = new THREE.ShaderMaterial({
+    vertexShader,
+    fragmentShader,
+    uniforms: {
+        time: { value: 0 },
+        paramsA: { value: new THREE.Vector3(1.2, 1.3, 1.1) },
+        paramsB: { value: new THREE.Vector3(2.0, 1.7, 2.3) },
+        morph: { value: 0 }
+    }
+});
+
+const points = new THREE.Points(geometry, material);
+scene.add(points);
+
+const composer = new EffectComposer(renderer);
+composer.addPass(new RenderPass(scene, camera));
+const bloom = new UnrealBloomPass(new THREE.Vector2(window.innerWidth, window.innerHeight), 1.2, 0.4, 0.85);
+composer.addPass(bloom);
+
+let target = 0;
+window.addEventListener('click', () => {
+    target = 1 - target;
+    material.uniforms.morph.value = target;
+});
+
+function animate(ms) {
+    material.uniforms.time.value = ms * 0.001;
+    controls.update();
+    composer.render();
+    requestAnimationFrame(animate);
+}
+
+animate(0);
+
+window.addEventListener('resize', () => {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    composer.setSize(window.innerWidth, window.innerHeight);
+});

--- a/style.css
+++ b/style.css
@@ -27,6 +27,15 @@ body {
     overflow-x: hidden;
 }
 
+#bg {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+}
+
 section {
     padding: 80px 0;
 }


### PR DESCRIPTION
## Summary
- add background `<canvas>` for particles
- implement Three.js particle system with GLSL shaders
- style canvas as a fullscreen fixed background
- add Netlify configuration file

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687558e7a110832f8c54505602e6a891